### PR TITLE
Fix shebang line

### DIFF
--- a/models/caffenet-yos/fetch.sh
+++ b/models/caffenet-yos/fetch.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 # Exit on first error
 set -e


### PR DESCRIPTION
Does this really run for you with `sh`? I get this error:
```
./fetch.sh: 6: ./fetch.sh: Syntax error: "(" unexpected
```