### PR TITLE
Compatibility fixes for newer numpy version 

### DIFF
--- a/core.py
+++ b/core.py
@@ -526,8 +526,8 @@ class LiveVis(object):
         self.panes['input'].data[:] = frame_disp
 
     def draw_help(self):
-        self.help_buffer[:] *= .7
-        self.help_pane.data *= .7
+        self.help_buffer[:] = self.help_buffer[:] * .7
+        self.help_pane.data[:] = self.help_pane.data[:] * .7
         
         #pane.data[:] = to_255(self.settings.window_background)
         defaults = {'face': getattr(cv2, self.settings.caffevis_help_face),

--- a/image_misc.py
+++ b/image_misc.py
@@ -58,7 +58,7 @@ def read_cam_frame(cap, saveto = None):
     frame = cv2_read_cap_rgb(cap, saveto = saveto)
     frame = frame[:,::-1,:]  # flip L-R for display
     frame -= frame.min()
-    frame *= (255.0 / (frame.max() + 1e-6))
+    frame = frame * (255.0 / (frame.max() + 1e-6))
     return frame
 
 def crop_to_square(frame):


### PR DESCRIPTION
This pull request fixes two crashes that happen when using a newer numpy version, one when changing to webcam and another when pressing 'h' for help.

The issue was a change in casting safety without backward compatibility. 
See http://docs.scipy.org/doc/numpy/release.html#future-changes

This pull request also solves the same issue yosinski/deep-visualization-toolbox#18 solves.