### PR TITLE
README.md: supply argument to make -j

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Starting from your caffe directory, run:
     $ git fetch --all
     $ git checkout --track -b deconv-deep-vis-toolbox yosinski/deconv-deep-vis-toolbox
     $ make clean
-    $ make -j
-    $ make -j pycaffe
+    $ make -j 4
+    $ make -j 4 pycaffe
 
 As noted above, feel free to compile in `CPU_ONLY` mode if desired.
 


### PR DESCRIPTION
Is there some environment where `make -j` without an argument produces good results? I just followed these instructions and was sad to be reminded that here in 2016 Linux still doesn't know what to do when a program eats all the RAM.

From `make(1)`:
> If the -j option is given without an argument, make will not limit the number of jobs that can run simultaneously.