### PR TITLE
Support for (1) different channel swap, (2) loading mean from binaryproto file (3) loading from image list and siamese image list 

### DIFF
--- a/caffevis/app.py
+++ b/caffevis/app.py
@@ -152,7 +152,7 @@ class CaffeVisApp(BaseApp):
 
         if self.proc_thread is None or not self.proc_thread.is_alive():
             # Start thread if it's not already running
-            self.proc_thread = CaffeProcThread(self.net, self.state,
+            self.proc_thread = CaffeProcThread(self.settings, self.net, self.state,
                                                self.settings.caffevis_frame_wait_sleep,
                                                self.settings.caffevis_pause_after_keys,
                                                self.settings.caffevis_heartbeat_required,
@@ -553,8 +553,21 @@ class CaffeVisApp(BaseApp):
             if len(grad_img.shape) == 2:
                 grad_img = np.tile(grad_img[:,:,np.newaxis], 3)
 
-            grad_img_resize = ensure_uint255_and_resize_to_fit(grad_img, pane.data.shape)
+            if (self.settings.static_files_input_mode ==  "siamese_image_list") and (grad_img.shape[2] == 6):
 
+                grad_img1 = grad_img[:, :, 0:3]
+                grad_img2 = grad_img[:, :, 3:6]
+
+                half_pane_shape = (pane.data.shape[0] / 2, pane.data.shape[1])
+                grad_img_disp1 = cv2.resize(grad_img1[:], half_pane_shape)
+                grad_img_disp2 = cv2.resize(grad_img2[:], half_pane_shape)
+
+                grad_img_disp = np.concatenate((grad_img_disp1, grad_img_disp2), axis=1)
+
+            else:
+                grad_img_disp = grad_img
+
+            grad_img_resize = ensure_uint255_and_resize_to_fit(grad_img_disp, pane.data.shape)
             pane.data[0:grad_img_resize.shape[0], 0:grad_img_resize.shape[1], :] = grad_img_resize
 
     def _draw_jpgvis_pane(self, pane):

--- a/caffevis/caffevis_helper.py
+++ b/caffevis/caffevis_helper.py
@@ -4,10 +4,16 @@ from image_misc import get_tiles_height_width, caffe_load_image
 
 
 
-def net_preproc_forward(net, img, data_hw):
-    appropriate_shape = data_hw + (3,)
+def net_preproc_forward(settings, net, img, data_hw):
+
+    if settings.static_files_input_mode == "siamese_image_list":
+        appropriate_shape = data_hw + (6,)
+    else:
+        appropriate_shape = data_hw + (3,)
+
     assert img.shape == appropriate_shape, 'img is wrong size (got %s but expected %s)' % (img.shape, appropriate_shape)
     #resized = caffe.io.resize_image(img, net.image_dims)   # e.g. (227, 227, 3)
+
     data_blob = net.transformer.preprocess('data', img)                # e.g. (3, 227, 227), mean subtracted and scaled to [0,255]
     data_blob = data_blob[np.newaxis,:,:,:]                   # e.g. (1, 3, 227, 227)
     output = net.forward(data=data_blob)

--- a/live_vis.py
+++ b/live_vis.py
@@ -316,7 +316,18 @@ class LiveVis(object):
                     key, hex(key), key_label, tag, tag)
 
     def display_frame(self, frame):
-        frame_disp = cv2.resize(frame[:], self.panes['input'].data.shape[:2][::-1])
+        if self.settings.static_files_input_mode == "siamese_image_list":
+            frame1 = frame[0]
+            frame2 = frame[1]
+            full_pane_shape = self.panes['input'].data.shape[:2][::-1]
+            half_pane_shape = (full_pane_shape[0] / 2, full_pane_shape[1])
+            frame_disp1 = cv2.resize(frame1[:], half_pane_shape)
+            frame_disp2 = cv2.resize(frame2[:], half_pane_shape)
+            frame_disp = np.concatenate((frame_disp1, frame_disp2), axis=1)
+
+        else:
+            frame_disp = cv2.resize(frame[:], self.panes['input'].data.shape[:2][::-1])
+
         self.panes['input'].data[:] = frame_disp
 
     def draw_help(self):

--- a/misc.py
+++ b/misc.py
@@ -3,7 +3,7 @@
 import os
 import time
 import errno
-
+import re
 
 
 class WithTimer:
@@ -49,3 +49,14 @@ def combine_dicts(dicts_tuple):
         for key in dictionary.keys():
             ret['%s%s' % (prefix, key)] = dictionary[key]
     return ret
+
+
+def tsplit(string, no_empty_strings, *delimiters):
+    # split string using multiple delimiters
+
+    pattern = '|'.join(map(re.escape, delimiters))
+    strings = re.split(pattern, string)
+    if no_empty_strings:
+        strings = filter(None, strings)
+
+    return strings

--- a/settings.py
+++ b/settings.py
@@ -101,13 +101,19 @@ if debug_window_panes:
 
 help_pane_loc = locals().get('help_pane_loc', (.07, .07, .86, .86))    # as a fraction of main window
 window_background = locals().get('window_background', (.2, .2, .2))
-stale_background =locals().get('stale_background',  (.3, .3, .2))
+stale_background = locals().get('stale_background',  (.3, .3, .2))
 static_files_dir = locals().get('static_files_dir', 'input_images')
 static_files_regexp = locals().get('static_files_regexp', '.*\.(jpg|jpeg|png)$')
 static_files_ignore_case = locals().get('static_files_ignore_case', True)
 # True to stretch to square, False to crop to square. (Can change at
 # runtime via 'stretch_mode' key.)
 static_file_stretch_mode = locals().get('static_file_stretch_mode', False)
+
+# contains the input mode for reading static images, can be: 'directory', 'image_list', 'siamese_image_list'
+static_files_input_mode = locals().get('static_files_input_mode', 'directory')
+
+# contains the file name to read, relevant only when static_files_input_mode is 'image_list' or 'siamese_image_list'
+static_files_input_file = locals().get('static_files_input_file', 'images_file_list.txt')
 
 # int, 0+. How many times to go through the main loop after a keypress
 # before resuming handling frames (0 to handle every frame as it

--- a/settings.py
+++ b/settings.py
@@ -298,6 +298,8 @@ caffevis_label_clr = locals().get('caffevis_label_clr', (.8,.8,.8))
 caffevis_label_fsize = locals().get('caffevis_label_fsize', 1.0 * global_font_size)
 caffevis_label_thick = locals().get('caffevis_label_thick', 1)
 
+# caffe net parameter - channel swap
+caffe_net_channel_swap = locals().get('caffe_net_channel_swap', (2,1,0))
 
 
 ####################################


### PR DESCRIPTION
- Added support for loading networks with any 'channel swap' definition, instead of assuming its (2,1,0)
This is done by defining a parameter for "caffe_net_channel_swap" which defaults to (2,1,0) for backwards compatibility.
- Added support for loading mean definition from a .binaryproto file format
- Added support for loading images from an image list or a siamese image list, in addition to the existing loading of images from directory.
This is done by adding parameters for setting static files input mode: can be "directory", "image_list" or "siamese_image_list"